### PR TITLE
feat(MSID-520): use dbt_cloud_user prefix on developer datasets

### DIFF
--- a/macros/generate_schema_name.sql
+++ b/macros/generate_schema_name.sql
@@ -10,7 +10,7 @@
     {%- elif env_var('DBT_CLOUD_INVOCATION_CONTEXT', '') == 'dev'
         and env_var('DBT_PROJECT_IS_POC', 'false') == 'true' -%}
 
-        dbt_user_{{ env_var('DBT_USER_ID', '') }}
+        dbt_cloud_user_{{ env_var('DBT_USER_ID', '') }}
 
     {%- else -%}
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the schema name generation logic for development environments in the `macros/generate_schema_name.sql` file. The main change is to update the prefix used for user-specific schemas.

* Changed the schema prefix from `dbt_user_` to `dbt_cloud_user_` for development contexts, ensuring naming consistency and clarity in identifying DBT Cloud users.