### PR TITLE
feat(MSID-533): remove reference to poc variable

### DIFF
--- a/macros/generate_schema_name.sql
+++ b/macros/generate_schema_name.sql
@@ -2,13 +2,11 @@
 
     {%- set default_schema = target.schema -%}
 
-    {% if env_var('DBT_CLOUD_INVOCATION_CONTEXT', '') == 'ci'
-        and env_var('DBT_PROJECT_IS_POC', 'false') == 'true' %}
+    {% if env_var('DBT_CLOUD_INVOCATION_CONTEXT', '') == 'ci' %}
 
         {{ default_schema }}
 
-    {%- elif env_var('DBT_CLOUD_INVOCATION_CONTEXT', '') == 'dev'
-        and env_var('DBT_PROJECT_IS_POC', 'false') == 'true' -%}
+    {%- elif env_var('DBT_CLOUD_INVOCATION_CONTEXT', '') == 'dev' -%}
 
         dbt_cloud_user_{{ env_var('DBT_USER_ID', '') }}
 


### PR DESCRIPTION
This pull request simplifies the logic for generating schema names in the `macros/generate_schema_name.sql` file. The main change is the removal of checks for the `DBT_PROJECT_IS_POC` environment variable, making the schema selection depend only on the `DBT_CLOUD_INVOCATION_CONTEXT` value.

Schema generation logic simplification:

* The conditional checks for both `ci` and `dev` contexts now ignore the `DBT_PROJECT_IS_POC` variable, relying solely on `DBT_CLOUD_INVOCATION_CONTEXT` to determine the schema name.