### PR TITLE
feat(MSID-645): update macroes using updated dbt model config structure

### DIFF
--- a/macros/generate_alias_name.sql
+++ b/macros/generate_alias_name.sql
@@ -1,6 +1,6 @@
 {% macro generate_alias_name(custom_alias_name=none, node=none) -%}
     {%- set meta_config = node.config.get('meta') or {} -%}
-    {%- set dataprodconfig = node.config.get('dataproduct', meta_config.dataproduct) -%}
+    {%- set dataprodconfig = node.config.get('dataproduct', meta_config.get('dataproduct')) -%}
 
     {%- if edna_dbt_lib.is_defined(dataprodconfig) and edna_dbt_lib.is_defined(dataprodconfig.get('version')) -%}
         {%- set v = (dataprodconfig.get('version') | trim('.0')) -%}

--- a/macros/generate_alias_name.sql
+++ b/macros/generate_alias_name.sql
@@ -1,5 +1,6 @@
 {% macro generate_alias_name(custom_alias_name=none, node=none) -%}
-    {%- set dataprodconfig = node.config.get('dataproduct') -%}
+    {%- set meta_config = node.config.get('meta') or {} -%}
+    {%- set dataprodconfig = node.config.get('dataproduct', meta_config.dataproduct) -%}
 
     {%- if edna_dbt_lib.is_defined(dataprodconfig) and edna_dbt_lib.is_defined(dataprodconfig.get('version')) -%}
         {%- set v = (dataprodconfig.get('version') | trim('.0')) -%}

--- a/macros/materialization/incremental_log.sql
+++ b/macros/materialization/incremental_log.sql
@@ -6,7 +6,8 @@
     {% set target_table_id    = bq_ids['table_id'] %}
 
     {# === Required config === #}
-    {% set run_window_column = config.get('run_window_column', 'insertTime') %}
+    {% set meta_config = config.get('meta') or {} %}
+    {% set run_window_column = config.get('run_window_column', meta_config.run_window_column or 'insertTime') %}
     {% if not log_table_id %}
         {% do exceptions.raise_compiler_error("incremental_log: `log_table_id` (project.dataset.table) is required.") %}
     {% endif %}
@@ -14,8 +15,8 @@
         {% do exceptions.raise_compiler_error("incremental_log: `run_window_column` is required and must appear in your SELECT.") %}
     {% endif %}
     {% set run_window_col_ts = "SAFE_CAST(" ~ run_window_column ~ " AS TIMESTAMP)" %}
-    {% set max_history_load_days = config.get('max_history_load_days', none) %}
-    {% set max_history_load_days_dev_ci = config.get('max_history_load_days_dev_ci', none) %}
+    {% set max_history_load_days = config.get('max_history_load_days', meta_config.max_history_load_days) %}
+    {% set max_history_load_days_dev_ci = config.get('max_history_load_days_dev_ci', meta_config.max_history_load_days_dev_ci) %}
 
 
 

--- a/macros/materialization/incremental_log.sql
+++ b/macros/materialization/incremental_log.sql
@@ -7,7 +7,7 @@
 
     {# === Required config === #}
     {% set meta_config = config.get('meta') or {} %}
-    {% set run_window_column = config.get('run_window_column', meta_config.run_window_column or 'insertTime') %}
+    {% set run_window_column = config.get('run_window_column', meta_config.get('run_window_column', 'insertTime')) %}
     {% if not log_table_id %}
         {% do exceptions.raise_compiler_error("incremental_log: `log_table_id` (project.dataset.table) is required.") %}
     {% endif %}
@@ -15,8 +15,8 @@
         {% do exceptions.raise_compiler_error("incremental_log: `run_window_column` is required and must appear in your SELECT.") %}
     {% endif %}
     {% set run_window_col_ts = "SAFE_CAST(" ~ run_window_column ~ " AS TIMESTAMP)" %}
-    {% set max_history_load_days = config.get('max_history_load_days', meta_config.max_history_load_days) %}
-    {% set max_history_load_days_dev_ci = config.get('max_history_load_days_dev_ci', meta_config.max_history_load_days_dev_ci) %}
+    {% set max_history_load_days = config.get('max_history_load_days', meta_config.get('max_history_load_days')) %}
+    {% set max_history_load_days_dev_ci = config.get('max_history_load_days_dev_ci', meta_config.get('max_history_load_days_dev_ci')) %}
 
 
 

--- a/macros/materialization/incremental_log.sql
+++ b/macros/materialization/incremental_log.sql
@@ -15,8 +15,8 @@
         {% do exceptions.raise_compiler_error("incremental_log: `run_window_column` is required and must appear in your SELECT.") %}
     {% endif %}
     {% set run_window_col_ts = "SAFE_CAST(" ~ run_window_column ~ " AS TIMESTAMP)" %}
-    {% set max_history_load_days = config.get('max_history_load_days', meta_config.get('max_history_load_days')) %}
-    {% set max_history_load_days_dev_ci = config.get('max_history_load_days_dev_ci', meta_config.get('max_history_load_days_dev_ci')) %}
+    {% set max_history_load_days = config.get('max_history_load_days', meta_config.get('max_history_load_days', none)) %}
+    {% set max_history_load_days_dev_ci = config.get('max_history_load_days_dev_ci', meta_config.get('max_history_load_days_dev_ci', none)) %}
 
 
 

--- a/macros/product_registration/register_dataproduct_metadata.sql
+++ b/macros/product_registration/register_dataproduct_metadata.sql
@@ -1,7 +1,7 @@
 {% macro register_dataproduct_metadata() %}
     {% if execute %}
         {% set meta_config = config.get('meta') or {} %}
-        {% set dataprodconfig = config.get('dataproduct', meta_config.dataproduct) %}
+        {% set dataprodconfig = config.get('dataproduct', meta_config.get('dataproduct')) %}
         {% if edna_dbt_lib.is_defined(dataprodconfig) %}
 
             {% set description = edna_dbt_lib.quote_replace(model.description) %}

--- a/macros/product_registration/register_dataproduct_metadata.sql
+++ b/macros/product_registration/register_dataproduct_metadata.sql
@@ -1,6 +1,7 @@
 {% macro register_dataproduct_metadata() %}
     {% if execute %}
-        {% set dataprodconfig = config.get('dataproduct') %}
+        {% set meta_config = config.get('meta') or {} %}
+        {% set dataprodconfig = config.get('dataproduct', meta_config.dataproduct) %}
         {% if edna_dbt_lib.is_defined(dataprodconfig) %}
 
             {% set description = edna_dbt_lib.quote_replace(model.description) %}

--- a/macros/product_registration/validate_dataproduct.sql
+++ b/macros/product_registration/validate_dataproduct.sql
@@ -2,7 +2,8 @@
     {% if execute %}
         {% set is_registered = edna_dbt_lib._is_registered_dataproduct(this) %}
 
-        {%- set dataproduct_config = config.get('dataproduct') -%}
+        {%- set meta_config = config.get('meta') or {} -%}
+        {%- set dataproduct_config = config.get('dataproduct', meta_config.dataproduct) -%}
         {%- set is_dataproduct = edna_dbt_lib.is_defined(dataproduct_config) or config.get('datacatalog', False) -%}
 
         {% if is_registered and not is_dataproduct %}

--- a/macros/product_registration/validate_dataproduct.sql
+++ b/macros/product_registration/validate_dataproduct.sql
@@ -3,7 +3,7 @@
         {% set is_registered = edna_dbt_lib._is_registered_dataproduct(this) %}
 
         {%- set meta_config = config.get('meta') or {} -%}
-        {%- set dataproduct_config = config.get('dataproduct', meta_config.dataproduct) -%}
+        {%- set dataproduct_config = config.get('dataproduct', meta_config.get('dataproduct')) -%}
         {%- set is_dataproduct = edna_dbt_lib.is_defined(dataproduct_config) or config.get('datacatalog', False) -%}
 
         {% if is_registered and not is_dataproduct %}

--- a/macros/utils/log_helpers.sql
+++ b/macros/utils/log_helpers.sql
@@ -243,7 +243,7 @@
     {% set calculated_run_window_end = edna_dbt_lib.apply_history_load_limit(max_history_load_days, window_start, max_history_load_days_dev_ci=max_history_load_days_dev_ci) %}
 
     {% set meta_config = config.get('meta') or {} %}
-    {% set table_window_end = config.get('table_window_end', meta_config.get('table_window_end')) %}
+    {% set table_window_end = config.get('table_window_end', meta_config.get('table_window_end', none)) %}
 
     {% if table_window_end %}
         {% set run_window_end = edna_dbt_lib.get_lowest_string_timestamp([calculated_run_window_end, table_window_end]) %}

--- a/macros/utils/log_helpers.sql
+++ b/macros/utils/log_helpers.sql
@@ -78,8 +78,8 @@
     {% set ctx = (env_var('DBT_CLOUD_INVOCATION_CONTEXT', '') or '') | lower %}
     {% set is_dev_ci = ctx in ['dev', 'ci'] %}
     {% set meta_config = config.get('meta') or {} %}
-    {% set source_dataset = config.get('source_dataset', meta_config.source_dataset) %}
-    {% set source_table = config.get('source_table', meta_config.source_table) %}
+    {% set source_dataset = config.get('source_dataset', meta_config.get('source_dataset')) %}
+    {% set source_table = config.get('source_table', meta_config.get('source_table')) %}
 
     {% set parts = table_id.split('.') %}
     {% if parts | length != 3 %}
@@ -243,7 +243,7 @@
     {% set calculated_run_window_end = edna_dbt_lib.apply_history_load_limit(max_history_load_days, window_start, max_history_load_days_dev_ci=max_history_load_days_dev_ci) %}
 
     {% set meta_config = config.get('meta') or {} %}
-    {% set table_window_end = config.get('table_window_end', meta_config.table_window_end) %}
+    {% set table_window_end = config.get('table_window_end', meta_config.get('table_window_end')) %}
 
     {% if table_window_end %}
         {% set run_window_end = edna_dbt_lib.get_lowest_string_timestamp([calculated_run_window_end, table_window_end]) %}


### PR DESCRIPTION
This pull request updates several macros to support reading configuration values from a nested `meta` config dictionary as a fallback, improving flexibility in how configs are provided. The main theme is to allow macro parameters to be specified either at the top level or within a `meta` section, making configuration more robust and consistent.

Configuration fallback enhancements:

* Updated all relevant macros (`generate_alias_name.sql`, `register_dataproduct_metadata.sql`, `validate_dataproduct.sql`, `incremental_log.sql`, and `log_helpers.sql`) to first look for config values at the top level, and if not present, fall back to the same key within the `meta` config dictionary. This affects parameters like `dataproduct`, `run_window_column`, `max_history_load_days`, `source_dataset`, `source_table`, and `table_window_end`. [[1]](diffhunk://#diff-08366416385ab2ff1c60d0d443872e64c61b104c86d7f8d38ecac4f410d43db6L2-R3) [[2]](diffhunk://#diff-f83cd7ee2f74992332f76296414b803c26b9bc66ded0c1c6e7e9e09e773e20f3L3-R4) [[3]](diffhunk://#diff-cc5c7a27006109fd92af44752ad91ed425b9c021e7710a0d0465f7e0030b67d1L5-R6) [[4]](diffhunk://#diff-2c0848c74065afdb3ef511e236ee6dd1483a33b8521e55e6862e6e62a19e6a7eL9-R19) [[5]](diffhunk://#diff-986c1fe78d01b43734cc43efd2b9fb27566835a0e63e3f25ff8730f76f4e53bbL80-R82) [[6]](diffhunk://#diff-986c1fe78d01b43734cc43efd2b9fb27566835a0e63e3f25ff8730f76f4e53bbL244-R249)

No functional changes are introduced beyond this improved handling of config values, so macro usage remains the same, but configuration can now be more flexible.