### PR TITLE
feat: create new helper macro for getting meta fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,27 +88,31 @@ Generates alias names for models, optionally incorporating versioning informatio
 
 #### `incremental_log`
 
-A BigQuery-specific materialization for incremental loads that includes logging of model run events. Supports partitioning and clustering configurations. Can be configured with `max_history_load_days` to limit the maximum amount of historical data loaded from the last successful run.
+A BigQuery-specific materialization for incremental loads that includes logging of model run events. Supports partitioning and clustering configurations. Can be configured with `max_history_load_days` to limit the maximum amount of historical data loaded from the last successful run. Custom config options can be set at the top level or under `meta` (via `config.meta_get`).
 
 #### `incremental_partition_merge`
 
-A BigQuery-specific materialization for incremental loads using MERGE operations with partition pruning. Optimized for partitioned tables with DAY granularity. Supports unique key matching, event-time based updates, and column filtering through `merge_update_columns` and `merge_exclude_columns` configurations. Automatically prunes partitions to avoid scanning the entire table, satisfying BigQuery's `require_partition_filter` requirement. Supports standard dbt pre and post hooks.
+A BigQuery-specific materialization for incremental loads using MERGE operations with partition pruning. Optimized for partitioned tables with DAY granularity. Supports unique key matching, event-time based updates, and column filtering through `merge_update_columns` and `merge_exclude_columns` configurations. Automatically prunes partitions to avoid scanning the entire table, satisfying BigQuery's `require_partition_filter` requirement. Supports standard dbt pre and post hooks. Custom config options can be set at the top level or under `meta` (via `config.meta_get`).
 
 ### Product Registration
 
 #### `validate_dataproduct()`
 
-Validates dataproduct configurations, including preview where clauses, dataset membership, column changes, and semantic versioning.
+Validates dataproduct configurations, including preview where clauses, dataset membership, column changes, and semantic versioning. Dataproduct config can be set at the top level or under `meta` (via `config.meta_get`).
 
 #### `register_dataproduct_metadata()`
 
-Registers or updates dataproduct metadata in the dataplatform, including description, columns, labels, size information, and versioning details.
+Registers or updates dataproduct metadata in the dataplatform, including description, columns, labels, size information, and versioning details. Dataproduct config can be set at the top level or under `meta` (via `config.meta_get`).
 
 #### Helper Macros
 
 ##### `is_defined(item)`
 
 Checks if an item is defined, not null, and not an empty string.
+
+##### `get_config_or_meta(config_obj, key, default=none)`
+
+Resolves a config value from `meta` first (using `config.meta_get` when available) and falls back to top-level config without triggering dbt warnings.
 
 ##### `create_tmp_relation(compiled_sql, target_relation)`
 

--- a/macros/generate_alias_name.sql
+++ b/macros/generate_alias_name.sql
@@ -1,6 +1,5 @@
 {% macro generate_alias_name(custom_alias_name=none, node=none) -%}
-    {%- set meta_config = node.config.get('meta') or {} -%}
-    {%- set dataprodconfig = node.config.get('dataproduct', meta_config.get('dataproduct')) -%}
+    {%- set dataprodconfig = edna_dbt_lib.get_config_or_meta(node.config, 'dataproduct', none) -%}
 
     {%- if edna_dbt_lib.is_defined(dataprodconfig) and edna_dbt_lib.is_defined(dataprodconfig.get('version')) -%}
         {%- set v = (dataprodconfig.get('version') | trim('.0')) -%}

--- a/macros/macro_docs.yml
+++ b/macros/macro_docs.yml
@@ -35,6 +35,7 @@ macros:
       `edna_dbt_lib.bq_ids_for_relation(this)`.
 
       **Config options (set via `config()` in models):**
+      Options can be set either at the top level or under `meta` (via `config.meta_get`).
       - `run_window_column` *(string, default: `insertTime`)* - timestamp column used for incremental windowing.
       - `max_history_load_days` *(string, optional)* - maximum number of days of historical data to load from the last successful run. If the time since the last successful run exceeds this limit, the current run window end will be limited to prevent excessive data loading.
       - `max_history_load_days_dev_ci` *(string, optional)* - override for max_history_load_days in dev/ci environments. If not set, defaults to 1 day in dev/ci.
@@ -66,6 +67,7 @@ macros:
       - `unique_key` *(string|list)* - Column(s) that uniquely identify rows for MERGE matching.
 
       **Optional config options:**
+      Options can be set either at the top level or under `meta` (via `config.meta_get`) where applicable.
       - `event_time` *(string)* - Timestamp column for recency-based updates. Only updates existing rows if the new row has a newer event_time.
       - `merge_update_columns` *(list)* - Whitelist of columns to update during MERGE.
       - `merge_exclude_columns` *(list)* - Blacklist of columns to exclude from updates.
@@ -82,7 +84,8 @@ macros:
     description: >
       Validate that a model configured as a dataproduct meets registration
       expectations: preview where clause syntax, same-dataset placement,
-      column additions/removals and semantic versioning.
+      column additions/removals and semantic versioning. Dataproduct config may
+      be set at the top level or under `meta` (via `config.meta_get`).
     arguments: []
 
   - name: register_dataproduct_metadata
@@ -91,6 +94,8 @@ macros:
       dataplatform table. Captures description, display name, owner, columns,
       labels, size info and version information. 
       Currently not used. Replaced by edna-data-api.DataproductAggregation.
+      Dataproduct config may be set at the top level or under `meta`
+      (via `config.meta_get`).
     arguments: []
 
   - name: is_defined
@@ -100,6 +105,23 @@ macros:
     arguments:
       - name: item
         description: Value to test
+        type: any
+
+  - name: get_config_or_meta
+    description: >
+      Resolve a config value from `meta` first (using `config.meta_get` when
+      available) and fall back to the top-level config. This avoids dbt warnings
+      when custom configs are defined under `meta` while keeping backward
+      compatibility.
+    arguments:
+      - name: config_obj
+        description: The config object to inspect (e.g., `config` or `node.config`).
+        type: object
+      - name: key
+        description: Config key to resolve.
+        type: string
+      - name: default
+        description: Optional default value if not found.
         type: any
 
   - name: create_tmp_relation

--- a/macros/materialization/incremental_log.sql
+++ b/macros/materialization/incremental_log.sql
@@ -6,8 +6,7 @@
     {% set target_table_id    = bq_ids['table_id'] %}
 
     {# === Required config === #}
-    {% set meta_config = config.get('meta') or {} %}
-    {% set run_window_column = config.get('run_window_column', meta_config.get('run_window_column', 'insertTime')) %}
+    {% set run_window_column = edna_dbt_lib.get_config_or_meta(config, 'run_window_column', 'insertTime') %}
     {% if not log_table_id %}
         {% do exceptions.raise_compiler_error("incremental_log: `log_table_id` (project.dataset.table) is required.") %}
     {% endif %}
@@ -15,8 +14,8 @@
         {% do exceptions.raise_compiler_error("incremental_log: `run_window_column` is required and must appear in your SELECT.") %}
     {% endif %}
     {% set run_window_col_ts = "SAFE_CAST(" ~ run_window_column ~ " AS TIMESTAMP)" %}
-    {% set max_history_load_days = config.get('max_history_load_days', meta_config.get('max_history_load_days', none)) %}
-    {% set max_history_load_days_dev_ci = config.get('max_history_load_days_dev_ci', meta_config.get('max_history_load_days_dev_ci', none)) %}
+    {% set max_history_load_days = edna_dbt_lib.get_config_or_meta(config, 'max_history_load_days', none) %}
+    {% set max_history_load_days_dev_ci = edna_dbt_lib.get_config_or_meta(config, 'max_history_load_days_dev_ci', none) %}
 
 
 

--- a/macros/product_registration/register_dataproduct_metadata.sql
+++ b/macros/product_registration/register_dataproduct_metadata.sql
@@ -1,7 +1,6 @@
 {% macro register_dataproduct_metadata() %}
     {% if execute %}
-        {% set meta_config = config.get('meta') or {} %}
-        {% set dataprodconfig = config.get('dataproduct', meta_config.get('dataproduct')) %}
+        {% set dataprodconfig = edna_dbt_lib.get_config_or_meta(config, 'dataproduct', none) %}
         {% if edna_dbt_lib.is_defined(dataprodconfig) %}
 
             {% set description = edna_dbt_lib.quote_replace(model.description) %}

--- a/macros/product_registration/validate_dataproduct.sql
+++ b/macros/product_registration/validate_dataproduct.sql
@@ -2,8 +2,7 @@
     {% if execute %}
         {% set is_registered = edna_dbt_lib._is_registered_dataproduct(this) %}
 
-        {%- set meta_config = config.get('meta') or {} -%}
-        {%- set dataproduct_config = config.get('dataproduct', meta_config.get('dataproduct')) -%}
+        {%- set dataproduct_config = edna_dbt_lib.get_config_or_meta(config, 'dataproduct', none) -%}
         {%- set is_dataproduct = edna_dbt_lib.is_defined(dataproduct_config) or config.get('datacatalog', False) -%}
 
         {% if is_registered and not is_dataproduct %}

--- a/macros/utils/config_helpers.sql
+++ b/macros/utils/config_helpers.sql
@@ -1,0 +1,15 @@
+{# Resolve config values from meta or top-level config without triggering warnings. #}
+{% macro get_config_or_meta(config_obj, key, default=none) %}
+    {% if config_obj.meta_get is defined %}
+        {% set meta_value = config_obj.meta_get(key) %}
+    {% else %}
+        {% set meta_dict = config_obj.get('meta') or {} %}
+        {% set meta_value = meta_dict.get(key) %}
+    {% endif %}
+
+    {% if meta_value is not none %}
+        {{ return(meta_value) }}
+    {% endif %}
+
+    {{ return(config_obj.get(key, default)) }}
+{% endmacro %}

--- a/macros/utils/log_helpers.sql
+++ b/macros/utils/log_helpers.sql
@@ -77,9 +77,8 @@
 {% macro get_last_successful_run_window_end(log_table_id, table_id, default='1900-01-01 00:00:00.000000 UTC') %}
     {% set ctx = (env_var('DBT_CLOUD_INVOCATION_CONTEXT', '') or '') | lower %}
     {% set is_dev_ci = ctx in ['dev', 'ci'] %}
-    {% set meta_config = config.get('meta') or {} %}
-    {% set source_dataset = config.get('source_dataset', meta_config.get('source_dataset')) %}
-    {% set source_table = config.get('source_table', meta_config.get('source_table')) %}
+    {% set source_dataset = edna_dbt_lib.get_config_or_meta(config, 'source_dataset', none) %}
+    {% set source_table = edna_dbt_lib.get_config_or_meta(config, 'source_table', none) %}
 
     {% set parts = table_id.split('.') %}
     {% if parts | length != 3 %}
@@ -242,8 +241,7 @@
 {% macro apply_history_load_limit_adjusted(max_history_load_days, window_start, max_history_load_days_dev_ci=None) %}
     {% set calculated_run_window_end = edna_dbt_lib.apply_history_load_limit(max_history_load_days, window_start, max_history_load_days_dev_ci=max_history_load_days_dev_ci) %}
 
-    {% set meta_config = config.get('meta') or {} %}
-    {% set table_window_end = config.get('table_window_end', meta_config.get('table_window_end', none)) %}
+    {% set table_window_end = edna_dbt_lib.get_config_or_meta(config, 'table_window_end', none) %}
 
     {% if table_window_end %}
         {% set run_window_end = edna_dbt_lib.get_lowest_string_timestamp([calculated_run_window_end, table_window_end]) %}

--- a/macros/utils/log_helpers.sql
+++ b/macros/utils/log_helpers.sql
@@ -77,8 +77,8 @@
 {% macro get_last_successful_run_window_end(log_table_id, table_id, default='1900-01-01 00:00:00.000000 UTC') %}
     {% set ctx = (env_var('DBT_CLOUD_INVOCATION_CONTEXT', '') or '') | lower %}
     {% set is_dev_ci = ctx in ['dev', 'ci'] %}
-    {% set source_dataset = edna_dbt_lib.get_config_or_meta(config, 'source_dataset', none) %}
-    {% set source_table = edna_dbt_lib.get_config_or_meta(config, 'source_table', none) %}
+    {% set source_dataset = edna_dbt_lib.get_config_or_meta(config, 'source_dataset') %}
+    {% set source_table = edna_dbt_lib.get_config_or_meta(config, 'source_table') %}
 
     {% set parts = table_id.split('.') %}
     {% if parts | length != 3 %}


### PR DESCRIPTION
This pull request improves how configuration options are resolved in dbt macros and materializations, allowing custom config values to be set either at the top level or under the `meta` key. It introduces a new helper macro, `get_config_or_meta`, to streamline this process and updates documentation and code to use this helper for consistency and to avoid dbt warnings.

**Config resolution improvements:**

* Added a new macro, `get_config_or_meta`, which first checks for a config value under `meta` (using `config.meta_get` if available), then falls back to the top-level config, ensuring backward compatibility and avoiding dbt warnings. (`macros/utils/config_helpers.sql`)
* Updated all relevant macros and materializations (such as `incremental_log`, `generate_alias_name`, `validate_dataproduct`, `register_dataproduct_metadata`, and log helper macros) to use `get_config_or_meta` for resolving config values instead of directly accessing `meta` or top-level config. [[1]](diffhunk://#diff-2c0848c74065afdb3ef511e236ee6dd1483a33b8521e55e6862e6e62a19e6a7eL9-R18) [[2]](diffhunk://#diff-08366416385ab2ff1c60d0d443872e64c61b104c86d7f8d38ecac4f410d43db6L2-R2) [[3]](diffhunk://#diff-cc5c7a27006109fd92af44752ad91ed425b9c021e7710a0d0465f7e0030b67d1L5-R5) [[4]](diffhunk://#diff-f83cd7ee2f74992332f76296414b803c26b9bc66ded0c1c6e7e9e09e773e20f3L3-R3) [[5]](diffhunk://#diff-986c1fe78d01b43734cc43efd2b9fb27566835a0e63e3f25ff8730f76f4e53bbL80-R81) [[6]](diffhunk://#diff-986c1fe78d01b43734cc43efd2b9fb27566835a0e63e3f25ff8730f76f4e53bbL245-R244)

**Documentation updates:**

* Updated macro documentation (`macro_docs.yml`) and the `README.md` to clarify that config options can be set at the top level or under `meta` (via `config.meta_get`), and described the new `get_config_or_meta` macro. [[1]](diffhunk://#diff-77c8b81b8d35d315af78cb9f4862f209b1f3d8cdc7bff96c6542f859a1ea4b56R38) [[2]](diffhunk://#diff-77c8b81b8d35d315af78cb9f4862f209b1f3d8cdc7bff96c6542f859a1ea4b56R70) [[3]](diffhunk://#diff-77c8b81b8d35d315af78cb9f4862f209b1f3d8cdc7bff96c6542f859a1ea4b56L85-R88) [[4]](diffhunk://#diff-77c8b81b8d35d315af78cb9f4862f209b1f3d8cdc7bff96c6542f859a1ea4b56R97-R98) [[5]](diffhunk://#diff-77c8b81b8d35d315af78cb9f4862f209b1f3d8cdc7bff96c6542f859a1ea4b56R110-R126) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R116)

These changes make configuration more flexible and robust, and ensure that custom config options work seamlessly whether defined at the top level or within `meta`.