### PR TITLE
MSID-735: add macros for cross-project dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dbt_modules/
 logs/
 .vscode/*
 dbt_internal_packages/
+.codex

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ This repository contains reusable macros and materializations for dbt projects.
         - [`cloud_env_sql_values()`](#cloud_env_sql_values)
         - [`log_model_run_started_pre_hook(relation=this, message=None, max_history_load_days=None)`](#log_model_run_started_pre_hookrelationthis-messagenone-max_history_load_daysnone)
         - [`log_model_run_succeeded_post_hook(relation=this, message=None, max_history_load_days=None)`](#log_model_run_succeeded_post_hookrelationthis-messagenone-max_history_load_daysnone)
+      - [Upstream Relations](#upstream-relations)
+        - [`cross_project_ref(project_name=none, model_name=none, source_name=none, table_name=none, version=none)`](#cross_project_refproject_namenone-model_namenone-source_namenone-table_namenone-versionnone)
       - [Quote Replace](#quote-replace)
         - [`quote_replace(string)`](#quote_replacestring)
   - [Examples](#examples)
@@ -61,6 +63,7 @@ This repository contains reusable macros and materializations for dbt projects.
     - [Product Registration](#product-registration-1)
     - [Using Core Macros](#using-core-macros)
     - [Using Utils](#using-utils)
+    - [Using `cross_project_ref`](#using-cross_project_ref)
 
 ## Overview
 
@@ -262,6 +265,25 @@ Post-hook macro to log the successful completion of a model run.
 
 Generate a comma-separated list of quoted DATE literals representing the distinct partitions affected by rows in a temporary relation. Used for BigQuery MERGE operations to satisfy require_partition_filter requirements and avoid scanning entire partitioned tables.
 
+#### Upstream Relations
+
+##### `cross_project_ref(project_name=none, model_name=none, source_name=none, table_name=none, version=none)`
+
+Resolve an upstream project dependency by `DBT_PROJECT_ENVIRONMENT`.
+
+- `DEV` uses `source(source_name, table_name)`
+- `Development`, `CI`, `TEST`, and `PROD` use cross-project `ref(project_name, model_name, version=...)`
+
+The macro fails fast if `DBT_PROJECT_ENVIRONMENT` is missing or unsupported, or if the required arguments for the selected strategy are not provided.
+
+Argument semantics:
+
+- `project_name`: upstream dbt project name used by cross-project `ref()`
+- `model_name`: logical upstream dbt model name used by `ref()`
+- `source_name`: downstream source name used by `source()` in `DEV`
+- `table_name`: physical upstream table name used by `source()` in `DEV`; defaults to `model_name` when omitted
+- `version`: optional dbt model version forwarded to cross-project `ref()`
+
 #### Quote Replace
 
 ##### `quote_replace(string)`
@@ -314,3 +336,59 @@ SELECT
   {{ edna_dbt_lib.hex_to_int('FF') }} AS int_value
 FROM my_table
 ```
+
+### Using `cross_project_ref`
+
+Use the macro directly from downstream models:
+
+```sql
+select *
+from {{ edna_dbt_lib.cross_project_ref(
+  project_name='msi',
+  model_name='my_model',
+  source_name='msi_curated',
+  version=1
+) }}
+```
+
+If the physical DEV table name differs from the logical dbt model name, set `table_name` explicitly:
+
+```sql
+select *
+from {{ edna_dbt_lib.cross_project_ref(
+  project_name='msi',
+  model_name='my_model',
+  source_name='msi_curated',
+  table_name='my_model_v2',
+  version=2
+) }}
+```
+
+Define a matching source in the downstream project for development environments that resolve via `source()`:
+
+```yaml
+version: 2
+
+sources:
+  - name: msi_curated
+    schema: msi_group_curated
+    tables:
+      - name: my_model
+```
+
+Behavior by environment:
+
+- `DEV`: use the declared source so downstream development jobs can point to explicit upstream development relations instead of relying on cross-project `ref()` resolution against the producer project's deployment metadata.
+- `Development`, `CI`, `TEST`, and `PROD`: use cross-project `ref()` and optional `version`. This matches your setup where CI uses the TEST BigQuery connection and should behave like TEST/STG.
+
+In dbt Mesh terms, this macro is intended for downstream projects that use project dependencies in `TEST` and `PROD`, but want explicit `source()` mappings in development-oriented environments.
+
+Required arguments depend on the active environment:
+
+- `DEV`: `source_name` is required. `table_name` is optional and defaults to `model_name`.
+- `Development`, `CI`, `TEST`, `PROD`: `project_name` and `model_name` are required. `version` is optional.
+
+Versioning note:
+
+- `ref()` resolves logical model versions, so `model_name` and `version` are enough in `Development`, `CI`, `TEST`, and `PROD`.
+- `source()` resolves physical table names only, so in `DEV` you must set `table_name` explicitly whenever the physical upstream table name differs from `model_name`, for example because aliasing or a new version changes the deployed table name.

--- a/macros/macro_docs.yml
+++ b/macros/macro_docs.yml
@@ -147,6 +147,32 @@ macros:
         description: The target relation to adjust for deployment environment.
         type: object
 
+  - name: cross_project_ref
+    description: >
+      Resolve an upstream project dependency differently by environment. Uses
+      `source(source_name, table_name)` when `DBT_PROJECT_ENVIRONMENT`
+      resolves to `DEV`, and uses cross-project
+      `ref(project_name, model_name, version=...)` when it resolves to
+      `Development`, `CI`, `TEST`, or `PROD`. Fails fast when the environment variable is missing,
+      unsupported, or when the required arguments for the selected resolution
+      strategy are not provided.
+    arguments:
+      - name: project_name
+        description: Upstream dbt project name used for cross-project `ref()` in CI/TEST/PROD.
+        type: string
+      - name: model_name
+        description: Upstream logical dbt model name used for cross-project `ref()` in Development/CI/TEST/PROD. Also used as the default physical source table name in DEV when `table_name` is not provided.
+        type: string
+      - name: source_name
+        description: Source name used for `source()` in DEV.
+        type: string
+      - name: table_name
+        description: Optional physical source table name used for `source()` in DEV. Defaults to `model_name` when omitted.
+        type: string
+      - name: version
+        description: Optional model version forwarded to cross-project `ref()` in Development/CI/TEST/PROD.
+        type: integer
+
   - name: _string_or_null
     description: "Return the quoted string or the SQL literal `null` if not defined."
     arguments:

--- a/macros/macro_docs.yml
+++ b/macros/macro_docs.yml
@@ -158,7 +158,7 @@ macros:
       strategy are not provided.
     arguments:
       - name: project_name
-        description: Upstream dbt project name used for cross-project `ref()` in CI/TEST/PROD.
+        description: Upstream dbt project name used for cross-project `ref()` in Development/CI/TEST/PROD.
         type: string
       - name: model_name
         description: Upstream logical dbt model name used for cross-project `ref()` in Development/CI/TEST/PROD. Also used as the default physical source table name in DEV when `table_name` is not provided.

--- a/macros/utils/cross_project_dependencies.sql
+++ b/macros/utils/cross_project_dependencies.sql
@@ -21,10 +21,16 @@
 {% endmacro %}
 
 {% macro _validate_upstream_relation_source_args(source_name, resolved_table_name, environment) %}
-    {% if source_name is not defined or source_name is none or source_name == '' or resolved_table_name is not defined or resolved_table_name is none or resolved_table_name == '' %}
+    {% if source_name is not defined or source_name is none or source_name == '' %}
         {% do exceptions.raise_compiler_error(
-            "cross_project_ref: source_name is required, and table_name must be provided when "
-            ~ "model_name cannot be used as the physical source table name, when DBT_PROJECT_ENVIRONMENT resolves to '" ~ environment ~ "'."
+            "cross_project_ref: source_name is required when DBT_PROJECT_ENVIRONMENT resolves to '" ~ environment ~ "'."
+        ) %}
+    {% endif %}
+
+    {% if resolved_table_name is not defined or resolved_table_name is none or resolved_table_name == '' %}
+        {% do exceptions.raise_compiler_error(
+            "cross_project_ref: provide model_name or table_name to resolve the physical source table name when "
+            ~ "DBT_PROJECT_ENVIRONMENT resolves to '" ~ environment ~ "'."
         ) %}
     {% endif %}
 {% endmacro %}
@@ -41,6 +47,7 @@
 {% macro cross_project_ref(project_name=none, model_name=none, source_name=none, table_name=none, version=none) %}
     {% set environment = edna_dbt_lib._get_dbt_project_environment() %}
     {% set resolved_table_name = table_name if table_name is defined and table_name is not none and table_name != '' else model_name %}
+    {% set resolved_version = version if version is defined and version is not none and (version | string | trim) != '' else none %}
 
     {# DEV should resolve through explicit sources instead of cross-project refs. #}
     {% if environment == 'DEV' %}
@@ -50,8 +57,8 @@
 
     {% do edna_dbt_lib._validate_upstream_relation_ref_args(project_name, model_name, environment) %}
 
-    {% if version is not none %}
-        {{ return(ref(project_name, model_name, version=version)) }}
+    {% if resolved_version is not none %}
+        {{ return(ref(project_name, model_name, version=resolved_version)) }}
     {% endif %}
 
     {{ return(ref(project_name, model_name)) }}

--- a/macros/utils/cross_project_dependencies.sql
+++ b/macros/utils/cross_project_dependencies.sql
@@ -1,0 +1,58 @@
+{% macro _get_dbt_project_environment() %}
+    {% set raw_environment = env_var('DBT_PROJECT_ENVIRONMENT', none) %}
+
+    {% if raw_environment is none or raw_environment | trim == '' %}
+        {% do exceptions.raise_compiler_error(
+            "cross_project_ref: env var 'DBT_PROJECT_ENVIRONMENT' must be set. "
+            ~ "Expected one of DEV, Development, CI, TEST or PROD."
+        ) %}
+    {% endif %}
+
+    {% set environment = raw_environment | trim | upper %}
+
+    {% if environment not in ['DEV', 'DEVELOPMENT', 'CI', 'TEST', 'PROD'] %}
+        {% do exceptions.raise_compiler_error(
+            "cross_project_ref: unsupported DBT_PROJECT_ENVIRONMENT '" ~ raw_environment ~ "'. "
+            ~ "Expected one of DEV, Development, CI, TEST or PROD."
+        ) %}
+    {% endif %}
+
+    {{ return(environment) }}
+{% endmacro %}
+
+{% macro _validate_upstream_relation_source_args(source_name, resolved_table_name, environment) %}
+    {% if source_name is not defined or source_name is none or source_name == '' or resolved_table_name is not defined or resolved_table_name is none or resolved_table_name == '' %}
+        {% do exceptions.raise_compiler_error(
+            "cross_project_ref: source_name is required, and table_name must be provided when "
+            ~ "model_name cannot be used as the physical source table name, when DBT_PROJECT_ENVIRONMENT resolves to '" ~ environment ~ "'."
+        ) %}
+    {% endif %}
+{% endmacro %}
+
+{% macro _validate_upstream_relation_ref_args(project_name, model_name, environment) %}
+    {% if project_name is not defined or project_name is none or project_name == '' or model_name is not defined or model_name is none or model_name == '' %}
+        {% do exceptions.raise_compiler_error(
+            "cross_project_ref: project_name and model_name are required when "
+            ~ "DBT_PROJECT_ENVIRONMENT resolves to '" ~ environment ~ "'."
+        ) %}
+    {% endif %}
+{% endmacro %}
+
+{% macro cross_project_ref(project_name=none, model_name=none, source_name=none, table_name=none, version=none) %}
+    {% set environment = edna_dbt_lib._get_dbt_project_environment() %}
+    {% set resolved_table_name = table_name if table_name is defined and table_name is not none and table_name != '' else model_name %}
+
+    {# DEV should resolve through explicit sources instead of cross-project refs. #}
+    {% if environment == 'DEV' %}
+        {% do edna_dbt_lib._validate_upstream_relation_source_args(source_name, resolved_table_name, environment) %}
+        {{ return(source(source_name, resolved_table_name)) }}
+    {% endif %}
+
+    {% do edna_dbt_lib._validate_upstream_relation_ref_args(project_name, model_name, environment) %}
+
+    {% if version is not none %}
+        {{ return(ref(project_name, model_name, version=version)) }}
+    {% endif %}
+
+    {{ return(ref(project_name, model_name)) }}
+{% endmacro %}


### PR DESCRIPTION
This pull request introduces a new macro, `cross_project_ref`, to streamline upstream dependency resolution in dbt projects by environment, along with comprehensive documentation and validation. The macro allows downstream models to reference upstream models or sources differently depending on the deployment environment, improving development workflows and CI/CD consistency.

**New Macro for Cross-Project References:**

* Added the `cross_project_ref` macro in `macros/utils/cross_project_dependencies.sql` that resolves upstream dependencies via `source()` in `DEV` and via cross-project `ref()` in `Development`, `CI`, `TEST`, or `PROD`. The macro validates arguments and fails fast for missing or unsupported environments.
* Introduced helper macros for environment detection and argument validation, ensuring robust and predictable behavior.

**Documentation Updates:**

* Updated `README.md` to document the new `cross_project_ref` macro, including usage examples, argument descriptions, and environment-specific behaviors. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R57-R66) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R268-R286) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R339-R394)
* Added a new section in `macros/macro_docs.yml` describing the macro and its arguments for auto-generated documentation.