### PR TITLE
feat(MSID-787): add option to full refresh incrementally on incremental_log

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ Generates alias names for models, optionally incorporating versioning informatio
 
 A BigQuery-specific materialization for incremental loads that includes logging of model run events. Supports partitioning and clustering configurations. Can be configured with `max_history_load_days` to limit the maximum amount of historical data loaded from the last successful run. Custom config options can be set at the top level or under `meta` (via `config.meta_get`).
 
+Full refresh supports `full_refresh_strategy`:
+
+- `rebuild_all` (default): recreates the table with all rows up to the current run window end and logs the initial window start.
+- `rebuild_incremental`: recreates the table from the initial window start and loads only the first incremental window, allowing later runs to catch up using `max_history_load_days`. `restart_incremental` is accepted as an alias.
+
+The strategy can be set on the model or overridden for a job/run with the `incremental_log_full_refresh_strategy` dbt variable:
+
+```bash
+dbt run -f --vars '{"incremental_log_full_refresh_strategy": "rebuild_incremental"}'
+```
+
+The run variable takes precedence over model config/meta.
+
 #### `incremental_partition_merge`
 
 A BigQuery-specific materialization for incremental loads using MERGE operations with partition pruning. Optimized for partitioned tables with DAY granularity. Supports unique key matching, event-time based updates, and column filtering through `merge_update_columns` and `merge_exclude_columns` configurations. Automatically prunes partitions to avoid scanning the entire table, satisfying BigQuery's `require_partition_filter` requirement. Supports standard dbt pre and post hooks. Custom config options can be set at the top level or under `meta` (via `config.meta_get`).

--- a/macros/macro_docs.yml
+++ b/macros/macro_docs.yml
@@ -39,6 +39,7 @@ macros:
       - `run_window_column` *(string, default: `insertTime`)* - timestamp column used for incremental windowing.
       - `max_history_load_days` *(string, optional)* - maximum number of days of historical data to load from the last successful run. If the time since the last successful run exceeds this limit, the current run window end will be limited to prevent excessive data loading.
       - `max_history_load_days_dev_ci` *(string, optional)* - override for max_history_load_days in dev/ci environments. If not set, defaults to 1 day in dev/ci.
+      - `full_refresh_strategy` *(string, default: `rebuild_all`)* - controls full refresh behavior. `rebuild_all` recreates the table with all rows up to the current run window end and logs the initial window start. `rebuild_incremental` recreates the table from the initial window start and loads only the first incremental window, allowing later runs to catch up using `max_history_load_days`. `restart_incremental` is accepted as an alias for `rebuild_incremental`. Can be overridden for a job/run with the `incremental_log_full_refresh_strategy` dbt variable, for example `dbt run -f --vars '{"incremental_log_full_refresh_strategy": "rebuild_incremental"}'`. The dbt variable takes precedence over model config/meta.
       - `source_dataset` *(string, optional)* - BigQuery dataset name for the source table used to determine earliest partition timestamp when no successful runs are found.
       - `source_table` *(string, optional)* - BigQuery table name for the source table used to determine earliest partition timestamp when no successful runs are found.
       - `partition_by` *(dict|string)* - standard BigQuery partitioning config.
@@ -483,6 +484,19 @@ macros:
       environment (project, user, invocation context) for insertion into log
       records.
     arguments: []
+
+  - name: get_initial_run_window_start
+    description: >
+      Return the initial run window start for a model. If source_table is configured,
+      this is derived from the earliest partition in the configured source table;
+      otherwise it falls back to the default timestamp.
+    arguments:
+      - name: table_id
+        description: Fully qualified BigQuery table id in the form project.dataset.table.
+        type: string
+      - name: default
+        description: Fallback timestamp used when no source partition can be resolved.
+        type: string
 
   - name: apply_history_load_limit
     description: >

--- a/macros/materialization/incremental_log.sql
+++ b/macros/materialization/incremental_log.sql
@@ -16,6 +16,19 @@
     {% set run_window_col_ts = "SAFE_CAST(" ~ run_window_column ~ " AS TIMESTAMP)" %}
     {% set max_history_load_days = edna_dbt_lib.get_config_or_meta(config, 'max_history_load_days', none) %}
     {% set max_history_load_days_dev_ci = edna_dbt_lib.get_config_or_meta(config, 'max_history_load_days_dev_ci', none) %}
+    {% set configured_full_refresh_strategy = edna_dbt_lib.get_config_or_meta(config, 'full_refresh_strategy', 'rebuild_all') %}
+    {% set full_refresh_strategy = var('incremental_log_full_refresh_strategy', configured_full_refresh_strategy) | lower %}
+    {% set valid_full_refresh_strategies = ['rebuild_all', 'rebuild_incremental', 'restart_incremental'] %}
+    {% if full_refresh_strategy not in valid_full_refresh_strategies %}
+        {% do exceptions.raise_compiler_error(
+            "incremental_log: `full_refresh_strategy` must be one of "
+            ~ (valid_full_refresh_strategies | join(', '))
+            ~ " but was '" ~ full_refresh_strategy ~ "'."
+        ) %}
+    {% endif %}
+    {% if full_refresh_strategy == 'restart_incremental' %}
+        {% set full_refresh_strategy = 'rebuild_incremental' %}
+    {% endif %}
 
 
 
@@ -38,15 +51,27 @@
         ) %}
     {% endif %}
 
-    {# Lower bound for incrementals: previous successful run's runWindowEnd #}
-    {% set prev_run_window_end = edna_dbt_lib.get_last_successful_run_window_end(log_table_id, target_table_id) %}
+    {# Window starts are mode-dependent:
+       - normal incremental continues from the last successful run
+       - full refresh logs the initial start because the table is rebuilt from scratch
+       - rebuild_incremental also uses the initial start as the lower bound #}
+    {% set is_rebuild_incremental = full_refresh_mode and full_refresh_strategy == 'rebuild_incremental' %}
+    {% set last_successful_run_window_end = edna_dbt_lib.get_last_successful_run_window_end(log_table_id, target_table_id) %}
+    {% if full_refresh_mode %}
+        {% set initial_run_window_start = edna_dbt_lib.get_initial_run_window_start(target_table_id) %}
+        {% set effective_run_window_start = initial_run_window_start %}
+        {% set history_limit_window_start = initial_run_window_start if is_rebuild_incremental else last_successful_run_window_end %}
+    {% else %}
+        {% set effective_run_window_start = last_successful_run_window_end %}
+        {% set history_limit_window_start = last_successful_run_window_end %}
+    {% endif %}
 
     {# === Establish the run window === #}
-    {% set current_run_window_end = edna_dbt_lib.apply_history_load_limit(max_history_load_days, prev_run_window_end, run_started_at, max_history_load_days_dev_ci) %}
+    {% set current_run_window_end = edna_dbt_lib.apply_history_load_limit(max_history_load_days, history_limit_window_start, run_started_at, max_history_load_days_dev_ci) %}
 
     {# Log the start of THIS run #}
     {%- call statement('log_model_run_started') -%}
-        {{ edna_dbt_lib.log_model_event(log_table_id, target_relation, 'model_run_started',  prev_run_window_end, current_run_window_end, ids=bq_ids, event_ts=model_run_started_time) }}
+        {{ edna_dbt_lib.log_model_event(log_table_id, target_relation, 'model_run_started',  effective_run_window_start, current_run_window_end, ids=bq_ids, event_ts=model_run_started_time) }}
     {%- endcall -%}
 
     {# Upper bound (applies to all builds) #}
@@ -54,9 +79,9 @@
         {{ run_window_col_ts }} <= TIMESTAMP('{{ current_run_window_end }}')
     {%- endset %}
 
-    {# Lower bound for incrementals: previous run start (we fetched it BEFORE logging this run) #}
+    {# Lower bound for incremental-style loads. #}
     {% set lower_bound_clause -%}
-        {{ run_window_col_ts }} > TIMESTAMP('{{ prev_run_window_end }}')
+        {{ run_window_col_ts }} > TIMESTAMP('{{ effective_run_window_start }}')
     {%- endset %}
 
     {% set ctx = (env_var('DBT_CLOUD_INVOCATION_CONTEXT', '') or '') | lower %}
@@ -99,17 +124,17 @@
                 partition_by,
                 False,
                 target_relation,
-                (filtered_sql_incr if is_dev_ci and not full_refresh_mode else filtered_sql_full)) }}
+                (filtered_sql_incr if is_rebuild_incremental or (is_dev_ci and not full_refresh_mode) else filtered_sql_full)) }}
         {%- endcall -%}
 
         {%- call statement('log_model_run_succeeded') -%}
-            {{ edna_dbt_lib.log_model_event(log_table_id, target_relation, 'model_run_succeeded', prev_run_window_end, current_run_window_end, ids=bq_ids) }}
+            {{ edna_dbt_lib.log_model_event(log_table_id, target_relation, 'model_run_succeeded', effective_run_window_start, current_run_window_end, ids=bq_ids) }}
         {%- endcall -%}
 
 
     {% else %}
 
-        {# === Incremental append: rows written in (prev_run_window_end, current_run_window_end] === #}
+        {# === Incremental append: rows written in (effective_run_window_start, current_run_window_end] === #}
 
         {% if on_schema_change != 'ignore' %}
             {# Build a temp table so we can reconcile schema robustly #}
@@ -129,7 +154,7 @@
             {% endcall %}
 
             {%- call statement('log_model_run_succeeded') -%}
-                {{ edna_dbt_lib.log_model_event(log_table_id, target_relation, 'model_run_succeeded', prev_run_window_end, current_run_window_end, ids=bq_ids) }}
+                {{ edna_dbt_lib.log_model_event(log_table_id, target_relation, 'model_run_succeeded', effective_run_window_start, current_run_window_end, ids=bq_ids) }}
             {%- endcall -%}
 
 
@@ -151,7 +176,7 @@
             {% endcall %}
 
             {%- call statement('log_model_run_succeeded') -%}
-                {{ edna_dbt_lib.log_model_event(log_table_id, target_relation, 'model_run_succeeded', prev_run_window_end, current_run_window_end, ids=bq_ids) }}
+                {{ edna_dbt_lib.log_model_event(log_table_id, target_relation, 'model_run_succeeded', effective_run_window_start, current_run_window_end, ids=bq_ids) }}
             {%- endcall -%}
 
         {% endif %}

--- a/macros/utils/log_helpers.sql
+++ b/macros/utils/log_helpers.sql
@@ -154,6 +154,9 @@
     {% set project_id = parts[0] %}
 
     {% if source_table is not none %}
+        {% if source_dataset is none %}
+            {% do exceptions.raise_compiler_error("get_initial_run_window_start: `source_dataset` is required when `source_table` is set.") %}
+        {% endif %}
         {{ return(edna_dbt_lib.get_earliest_partition_timestamp(project_id, source_dataset, source_table) or default) }}
     {% else %}
         {{ return(default) }}

--- a/macros/utils/log_helpers.sql
+++ b/macros/utils/log_helpers.sql
@@ -136,9 +136,27 @@
     {% endif %}
 
     {% if ts_str is none and source_table is not none %}
-        {{ return(edna_dbt_lib.get_earliest_partition_timestamp(project_id, source_dataset, source_table) or default) }}
+        {{ return(edna_dbt_lib.get_initial_run_window_start(table_id, default)) }}
     {% else %}
         {{ return(ts_str or default) }}
+    {% endif %}
+{% endmacro %}
+
+{# Initial window start used when a model should be rebuilt from the beginning. #}
+{% macro get_initial_run_window_start(table_id, default='1900-01-01 00:00:00.000000 UTC') %}
+    {% set source_dataset = edna_dbt_lib.get_config_or_meta(config, 'source_dataset') %}
+    {% set source_table = edna_dbt_lib.get_config_or_meta(config, 'source_table') %}
+
+    {% set parts = table_id.split('.') %}
+    {% if parts | length != 3 %}
+        {% do exceptions.raise_compiler_error("get_initial_run_window_start: table_id must be 'project.dataset.table' but was '" ~ table_id ~ "'") %}
+    {% endif %}
+    {% set project_id = parts[0] %}
+
+    {% if source_table is not none %}
+        {{ return(edna_dbt_lib.get_earliest_partition_timestamp(project_id, source_dataset, source_table) or default) }}
+    {% else %}
+        {{ return(default) }}
     {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
This pull request introduces enhanced configurability and control over the incremental load materialization for BigQuery models, specifically around how full refreshes are handled. It adds a new `full_refresh_strategy` option, allowing users to choose between rebuilding all data or only the initial incremental window during a full refresh, with support for overriding this behavior at runtime. The changes also include improved documentation and a new helper macro for determining the initial run window start.

**Incremental load materialization improvements:**

* Added a `full_refresh_strategy` configuration to the `incremental_log` materialization, allowing users to select between `rebuild_all` (default) and `rebuild_incremental` (or its alias `restart_incremental`). This determines whether a full refresh rebuilds the table with all historical data or just the first incremental window. The strategy can be set in model config/meta or overridden at runtime using the `incremental_log_full_refresh_strategy` dbt variable. [[1]](diffhunk://#diff-2c0848c74065afdb3ef511e236ee6dd1483a33b8521e55e6862e6e62a19e6a7eR19-R31) [[2]](diffhunk://#diff-77c8b81b8d35d315af78cb9f4862f209b1f3d8cdc7bff96c6542f859a1ea4b56R42) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R96-R108)
* Updated the incremental logic to use the correct run window start and end based on the selected strategy, ensuring accurate logging and data loading behavior during both normal and full refresh runs. [[1]](diffhunk://#diff-2c0848c74065afdb3ef511e236ee6dd1483a33b8521e55e6862e6e62a19e6a7eL41-R84) [[2]](diffhunk://#diff-2c0848c74065afdb3ef511e236ee6dd1483a33b8521e55e6862e6e62a19e6a7eL102-R137) [[3]](diffhunk://#diff-2c0848c74065afdb3ef511e236ee6dd1483a33b8521e55e6862e6e62a19e6a7eL132-R157) [[4]](diffhunk://#diff-2c0848c74065afdb3ef511e236ee6dd1483a33b8521e55e6862e6e62a19e6a7eL154-R179)

**Utility macro and documentation enhancements:**

* Introduced a new macro `get_initial_run_window_start` to determine the initial run window start timestamp, using the earliest partition in a configured source table if available. This is now used in the incremental logic and documented in the macro docs. [[1]](diffhunk://#diff-986c1fe78d01b43734cc43efd2b9fb27566835a0e63e3f25ff8730f76f4e53bbL139-R162) [[2]](diffhunk://#diff-77c8b81b8d35d315af78cb9f4862f209b1f3d8cdc7bff96c6542f859a1ea4b56R488-R500)
* Expanded the documentation in both the `README.md` and `macro_docs.yml` to describe the new `full_refresh_strategy` option, how to override it, and the purpose of the new macro. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R96-R108) [[2]](diffhunk://#diff-77c8b81b8d35d315af78cb9f4862f209b1f3d8cdc7bff96c6542f859a1ea4b56R42) [[3]](diffhunk://#diff-77c8b81b8d35d315af78cb9f4862f209b1f3d8cdc7bff96c6542f859a1ea4b56R488-R500)